### PR TITLE
fix(android): use proguard-android-optimize.txt for AGP 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
AGP 9 removed getDefaultProguardFile('proguard-android.txt'), so Gradle fails while evaluating this package on any app using AGP 9.

The block sets minifyEnabled false, so the file is never read. Switching to the -optimize name only stops the AGP 9 error. It still works on AGP 8.